### PR TITLE
Adding location to the reserved event

### DIFF
--- a/specs/bundle.txt
+++ b/specs/bundle.txt
@@ -298,7 +298,7 @@ WHEN:
 THEN:
   ReserveResp reservation:1
 EVENTS:
-  Reserved reservation:1  code:"sale"  items:{product:1  quantity:10}
+  Reserved reservation:1  code:"sale"  items:{product:1  quantity:10 location:1}
 
 ==========================================
 reserve non-existent sku


### PR DESCRIPTION
I think there is an inconsistency in the location definition:

The Reserved event at line 282 contains a location, the expected event here not.